### PR TITLE
remove check pods script and frameworks content

### DIFF
--- a/ios/ChainLibs.xcodeproj/project.pbxproj
+++ b/ios/ChainLibs.xcodeproj/project.pbxproj
@@ -104,7 +104,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "ChainLibs" */;
 			buildPhases = (
-				3194F1966C31B14CE19370E0 /* [CP] Check Pods Manifest.lock */,
 				BA3E4213236082F100247396 /* ShellScript */,
 				58B511D71A9E6C8500147676 /* Sources */,
 				58B511D81A9E6C8500147676 /* Frameworks */,
@@ -152,28 +151,6 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3194F1966C31B14CE19370E0 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ChainLibs-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		BA3E4213236082F100247396 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
This PR reflects to changes in the iOS side:

## 1. Remove check Pods Manifest script
<img width="873" alt="Screenshot 2020-01-23 at 16 09 50" src="https://user-images.githubusercontent.com/7271744/73016065-f2558d00-3dfb-11ea-8a7e-4a540a5d1221.png">


## 2. remove content in frameworks
<img width="382" alt="Screenshot 2020-01-23 at 16 10 19" src="https://user-images.githubusercontent.com/7271744/73016101-000b1280-3dfc-11ea-8676-a10011c947a5.png">

These two workarounds seem to fix current compilation issue.
